### PR TITLE
Several fixes for the zigapi module

### DIFF
--- a/examples/example-zigapi/src/invert_example.zig
+++ b/examples/example-zigapi/src/invert_example.zig
@@ -30,8 +30,8 @@ export fn invertGetFrame(n: c_int, activation_reason: vs.ActivationReason, insta
 
         var plane: u32 = 0;
         while (plane < d.vi.format.numPlanes) : (plane += 1) {
-            var srcp = src.getReadPtr(plane);
-            var dstp = dst.getWritePtr(plane);
+            var srcp = src.getReadSlice(plane);
+            var dstp = dst.getWriteSlice(plane);
 
             // getDimensions returns a tuple with [width, height, stride],
             // use getDimensions2 if you want a struct.

--- a/src/zigapi.zig
+++ b/src/zigapi.zig
@@ -107,13 +107,13 @@ pub const Frame = struct {
         };
     }
 
-    pub fn getReadPtr(self: Self, plane: u32) []const u8 {
+    pub fn getReadSlice(self: Self, plane: u32) []const u8 {
         const ptr = self.vsapi.?.getReadPtr.?(self.frame, @intCast(plane));
         const len = self.getHeight(plane) * self.getStride(plane);
         return ptr[0..len];
     }
 
-    pub fn getWritePtr(self: Self, plane: u32) []u8 {
+    pub fn getWriteSlice(self: Self, plane: u32) []u8 {
         const ptr = self.vsapi.?.getWritePtr.?(@constCast(self.frame), @intCast(plane));
         const len = self.getHeight(plane) * self.getStride(plane);
         return ptr[0..len];

--- a/src/zigapi.zig
+++ b/src/zigapi.zig
@@ -83,39 +83,39 @@ pub const Frame = struct {
         return self.vsapi.?.getFramePropertiesRW.?(@constCast(self.frame));
     }
 
-    pub fn geHeight(self: Self, plane: u32) u32 {
-        return @bitCast(self.vsapi.?.getFrameHeight.?(self.frame, @bitCast(plane)));
+    pub fn getHeight(self: Self, plane: u32) u32 {
+        return @intCast(self.vsapi.?.getFrameHeight.?(self.frame, @intCast(plane)));
     }
 
-    pub fn geWidth(self: Self, plane: u32) u32 {
-        return @bitCast(self.vsapi.?.getFrameWidth.?(self.frame, @bitCast(plane)));
+    pub fn getWidth(self: Self, plane: u32) u32 {
+        return @intCast(self.vsapi.?.getFrameWidth.?(self.frame, @intCast(plane)));
     }
 
     pub fn getStride(self: Self, plane: u32) u32 {
-        return @intCast(self.vsapi.?.getStride.?(self.frame, @bitCast(plane)));
+        return @intCast(self.vsapi.?.getStride.?(self.frame, @intCast(plane)));
     }
 
     pub fn getDimensions(self: Self, plane: u32) struct { u32, u32, u32 } {
-        return .{ self.geWidth(plane), self.geHeight(plane), self.getStride(plane) };
+        return .{ self.getWidth(plane), self.getHeight(plane), self.getStride(plane) };
     }
 
     pub fn getDimensions2(self: Self, plane: u32) struct { width: u32, height: u32, stride: u32 } {
         return .{
-            .width = self.geWidth(plane),
-            .height = self.geHeight(plane),
+            .width = self.getWidth(plane),
+            .height = self.getHeight(plane),
             .stride = self.getStride(plane),
         };
     }
 
     pub fn getReadPtr(self: Self, plane: u32) []const u8 {
-        const ptr = self.vsapi.?.getReadPtr.?(self.frame, @bitCast(plane));
-        const len = self.geHeight(plane) * self.getStride(plane);
+        const ptr = self.vsapi.?.getReadPtr.?(self.frame, @intCast(plane));
+        const len = self.getHeight(plane) * self.getStride(plane);
         return ptr[0..len];
     }
 
     pub fn getWritePtr(self: Self, plane: u32) []u8 {
-        const ptr = self.vsapi.?.getWritePtr.?(@constCast(self.frame), @bitCast(plane));
-        const len = self.geHeight(plane) * self.getStride(plane);
+        const ptr = self.vsapi.?.getWritePtr.?(@constCast(self.frame), @intCast(plane));
+        const len = self.getHeight(plane) * self.getStride(plane);
         return ptr[0..len];
     }
 };

--- a/src/zigapi.zig
+++ b/src/zigapi.zig
@@ -9,8 +9,8 @@ pub const Frame = struct {
     frame: ?*const vs.Frame,
 
     const Self = @This();
-    pub fn init(node: ?*vs.Node, n: c_int, frame_ctx: ?*vs.FrameContext, core: ?*vs.Core, vsapi: ?*const vs.API) Self {
-        const frame = vsapi.?.getFrameFilter.?(n, node, frame_ctx);
+    pub fn init(node: ?*vs.Node, n: u32, frame_ctx: ?*vs.FrameContext, core: ?*vs.Core, vsapi: ?*const vs.API) Self {
+        const frame = vsapi.?.getFrameFilter.?(@intCast(n), node, frame_ctx);
         return .{
             .frame_ctx = frame_ctx,
             .core = core,
@@ -160,9 +160,9 @@ pub const Map = struct {
         return if (err == .Success) val else null;
     }
 
-    pub fn getInt2(self: Self, comptime T: type, comptime key: []const u8, index: c_int) ?T {
+    pub fn getInt2(self: Self, comptime T: type, comptime key: []const u8, index: u32) ?T {
         var err: vs.MapPropertyError = undefined;
-        const val: T = math.lossyCast(T, self.vsapi.?.mapGetInt.?(self.in, key.ptr, index, &err));
+        const val: T = math.lossyCast(T, self.vsapi.?.mapGetInt.?(self.in, key.ptr, @intCast(index), &err));
         return if (err == .Success) val else null;
     }
 
@@ -172,9 +172,9 @@ pub const Map = struct {
         return if (err == .Success) val else null;
     }
 
-    pub fn getFloat2(self: Self, comptime T: type, comptime key: []const u8, index: c_int) ?T {
+    pub fn getFloat2(self: Self, comptime T: type, comptime key: []const u8, index: u32) ?T {
         var err: vs.MapPropertyError = undefined;
-        const val: T = math.lossyCast(T, self.vsapi.?.mapGetFloat.?(self.in, key.ptr, index, &err));
+        const val: T = math.lossyCast(T, self.vsapi.?.mapGetFloat.?(self.in, key.ptr, @intCast(index), &err));
         return if (err == .Success) val else null;
     }
 
@@ -184,9 +184,9 @@ pub const Map = struct {
         return if (err == .Success) val else null;
     }
 
-    pub fn getBool2(self: Self, comptime key: []const u8, index: c_int) ?bool {
+    pub fn getBool2(self: Self, comptime key: []const u8, index: u32) ?bool {
         var err: vs.MapPropertyError = undefined;
-        const val = self.vsapi.?.mapGetInt.?(self.in, key.ptr, index, &err) != 0;
+        const val = self.vsapi.?.mapGetInt.?(self.in, key.ptr, @intCast(index), &err) != 0;
         return if (err == .Success) val else null;
     }
 

--- a/test/src/invert_example.zig
+++ b/test/src/invert_example.zig
@@ -30,8 +30,8 @@ export fn invertGetFrame(n: c_int, activation_reason: vs.ActivationReason, insta
 
         var plane: u32 = 0;
         while (plane < d.vi.format.numPlanes) : (plane += 1) {
-            var srcp = src.getReadPtr(plane);
-            var dstp = dst.getWritePtr(plane);
+            var srcp = src.getReadSlice(plane);
+            var dstp = dst.getWriteSlice(plane);
 
             // getDimensions returns a tuple with [width, height, stride],
             // use getDimensions2 if you want a struct.


### PR DESCRIPTION
This fixes:
* https://github.com/dnjulek/vapoursynth-zig/issues/4
* https://github.com/dnjulek/vapoursynth-zig/issues/5
* https://github.com/dnjulek/vapoursynth-zig/issues/6

It does *not* fix: https://github.com/dnjulek/vapoursynth-zig/issues/3

The latter may take some re-adjustment of the `Map` class. Specifically zigapi's `Map` actually wraps 2 VS Maps, not just one. We might want to slim it down to just a 1:1 relationship, since as the `getPropertiesRO/RW` methods show, there's plenty of times when we just want to operate on a single VS Map.