### PR TITLE
optionally build with API 4.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,16 @@
 const std = @import("std");
 
-pub const min_zig_version = std.SemanticVersion{ .major = 0, .minor = 14, .patch = 0, .pre = "dev.3445" };
+pub const min_zig_version = std.SemanticVersion{ .major = 0, .minor = 14, .patch = 0 };
+
+pub const VSAPI4 = enum(i32) {
+    minor_0 = 0,
+    minor_1 = 1,
+};
+
+pub const VSSAPI4 = enum(i32) {
+    minor_1 = 1,
+    minor_2 = 2,
+};
 
 pub fn build(b: *std.Build) void {
     ensureZigVersion() catch return;
@@ -8,17 +18,13 @@ pub fn build(b: *std.Build) void {
     _ = b.standardTargetOptions(.{});
     _ = b.standardOptimizeOption(.{});
 
-    const vs_use_api_41 = b.option(bool, "vs_use_api_41", "Use VapourSynth API 4.1") orelse false;
-    const vs_use_latest_api = b.option(bool, "vs_use_latest_api", "Use Latest VapourSynth API") orelse false;
-    const vsscript_use_api_42 = b.option(bool, "vsscript_use_api_42", "Use VSScript API 4.2") orelse false;
-    const vsscript_use_latest_api = b.option(bool, "vsscript_use_latest_api", "Use Latest VSScript API") orelse false;
+    const vsapi4_minor: VSAPI4 = b.option(VSAPI4, "vsapi4_minor", "Set VapourSynth API4 minor") orelse .minor_1;
+    const vssapi4_minor: VSSAPI4 = b.option(VSSAPI4, "vssapi4_minor", "Set VSScript API4 minor") orelse .minor_2;
 
     // Create build options
     const options = b.addOptions();
-    options.addOption(bool, "vs_use_api_41", vs_use_api_41);
-    options.addOption(bool, "vs_use_latest_api", vs_use_latest_api);
-    options.addOption(bool, "vsscript_use_api_42", vsscript_use_api_42);
-    options.addOption(bool, "vsscript_use_latest_api", vsscript_use_latest_api);
+    options.addOption(VSAPI4, "vsapi4_minor", vsapi4_minor);
+    options.addOption(VSSAPI4, "vssapi4_minor", vssapi4_minor);
 
     // Expose this as a module that others can import
     _ = b.addModule("vapoursynth", .{

--- a/build.zig
+++ b/build.zig
@@ -8,9 +8,24 @@ pub fn build(b: *std.Build) void {
     _ = b.standardTargetOptions(.{});
     _ = b.standardOptimizeOption(.{});
 
+    const vs_use_api_41 = b.option(bool, "vs_use_api_41", "Use VapourSynth API 4.1") orelse false;
+    const vs_use_latest_api = b.option(bool, "vs_use_latest_api", "Use Latest VapourSynth API") orelse false;
+    const vsscript_use_api_42 = b.option(bool, "vsscript_use_api_42", "Use VSScript API 4.2") orelse false;
+    const vsscript_use_latest_api = b.option(bool, "vsscript_use_latest_api", "Use Latest VSScript API") orelse false;
+
+    // Create build options
+    const options = b.addOptions();
+    options.addOption(bool, "vs_use_api_41", vs_use_api_41);
+    options.addOption(bool, "vs_use_latest_api", vs_use_latest_api);
+    options.addOption(bool, "vsscript_use_api_42", vsscript_use_api_42);
+    options.addOption(bool, "vsscript_use_latest_api", vsscript_use_latest_api);
+
     // Expose this as a module that others can import
     _ = b.addModule("vapoursynth", .{
         .root_source_file = b.path("src/module.zig"),
+        .imports = &.{
+            .{ .name = "build_options", .module = options.createModule() },
+        },
     });
 }
 

--- a/src/vapoursynth4.zig
+++ b/src/vapoursynth4.zig
@@ -11,7 +11,7 @@ pub inline fn makeVersion(major: c_int, minor: c_int) c_int {
 /// Major API version.
 pub const VAPOURSYNTH_API_MAJOR: c_int = 4;
 /// Minor API version. It is bumped when new functions are added to API or core behavior is noticeably changed.
-pub const VAPOURSYNTH_API_MINOR: c_int = if (build_options.vs_use_api_41 or build_options.vs_use_latest_api) 1 else 0;
+pub const VAPOURSYNTH_API_MINOR: c_int = @intFromEnum(build_options.vsapi4_minor);
 /// API version. The high 16 bits are VAPOURSYNTH_API_MAJOR, the low 16 bits are VAPOURSYNTH_API_MINOR.
 pub const VAPOURSYNTH_API_VERSION: c_int = makeVersion(VAPOURSYNTH_API_MAJOR, VAPOURSYNTH_API_MINOR);
 /// The number of audio samples in an audio frame. It is a static number to make it possible to calculate which audio frames are needed to retrieve specific samples.

--- a/src/vsscript4.zig
+++ b/src/vsscript4.zig
@@ -5,7 +5,7 @@ const build_options = @import("build_options");
 const vs = @import("vapoursynth4.zig");
 
 pub const VSSCRIPT_API_MAJOR: c_int = 4;
-pub const VSSCRIPT_API_MINOR: c_int = if (build_options.vsscript_use_api_42 or build_options.vsscript_use_latest_api) 2 else 1;
+pub const VSSCRIPT_API_MINOR: c_int = @intFromEnum(build_options.vssapi4_minor);
 pub const VSSCRIPT_API_VERSION: c_int = vs.makeVersion(VSSCRIPT_API_MAJOR, VSSCRIPT_API_MINOR);
 
 pub const VSScript = opaque {};

--- a/src/vsscript4.zig
+++ b/src/vsscript4.zig
@@ -1,9 +1,11 @@
 //! https://github.com/vapoursynth/vapoursynth/blob/master/include/VSScript4.h
+const builtin = @import("builtin");
+const build_options = @import("build_options");
 
 const vs = @import("vapoursynth4.zig");
 
 pub const VSSCRIPT_API_MAJOR: c_int = 4;
-pub const VSSCRIPT_API_MINOR: c_int = 2;
+pub const VSSCRIPT_API_MINOR: c_int = if (build_options.vsscript_use_api_42 or build_options.vsscript_use_latest_api) 2 else 1;
 pub const VSSCRIPT_API_VERSION: c_int = vs.makeVersion(VSSCRIPT_API_MAJOR, VSSCRIPT_API_MINOR);
 
 pub const VSScript = opaque {};
@@ -43,9 +45,12 @@ pub const API = extern struct {
     /// Set whether or not the working directory is temporarily changed to the same
     /// location as the script file when evaluateFile is called. Off by default.
     evalSetWorkingDir: ?*const fn (handle: ?*VSScript, set_cwd: c_int) callconv(.C) void,
-    /// Write a list of set output index values to dst but at most size values.
-    /// Always returns the total number of available output index values.
-    getAvailableOutputNodes: ?*const fn (handle: ?*VSScript, size: c_int, dst: ?[*]i32) callconv(.C) c_int,
+
+    pub usingnamespace if (VSSCRIPT_API_MINOR >= 2) struct {
+        /// Write a list of set output index values to dst but at most size values.
+        /// Always returns the total number of available output index values.
+        getAvailableOutputNodes: ?*const fn (handle: ?*VSScript, size: c_int, dst: ?[*]i32) callconv(.C) c_int,
+    } else struct {};
 };
 
 pub extern fn getVSScriptAPI(version: c_int) ?*const API;


### PR DESCRIPTION
As most of the plugin do not need API 4.1, its better to set API 4.0 as default target version like what we do in c++ plugin.
For plugin using API 4.1 feature like `rpFrameReuseLastOnly`, add `.vs_use_api_41 = true` to vapoursynth_dep args in build.zig.
e.g.
```zig
    const vapoursynth_dep = b.dependency("vapoursynth", .{
        .target = target,
        .optimize = optimize,
        .vs_use_api_41 = true,
    });
```