### PR TITLE
Add addFrameRef API to ZFrame, lower min zig version.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub const min_zig_version = std.SemanticVersion{ .major = 0, .minor = 16, .patch = 0 };
+pub const min_zig_version = std.SemanticVersion{ .major = 0, .minor = 15, .patch = 1 };
 
 pub const VSAPI4 = enum(i32) {
     minor_0 = 0,

--- a/src/zigapi/zframe.zig
+++ b/src/zigapi/zframe.zig
@@ -96,6 +96,14 @@ pub fn ZFrame(comptime FT: type) type {
             };
         }
 
+        /// Increments the reference count of a frame. Returns said frame for convenience.
+        pub fn addFrameRef(self: *const Self) ZFrame(*Frame) {
+            return .{
+                .zapi = self.zapi,
+                .frame = self.zapi.addFrameRef(self.frame).?,
+            };
+        }
+
         /// Returns a read/write Map to a frame’s properties. The Map is valid as long as the frame lives.
         pub fn getPropertiesRW(self: *const Self) ZAPI.ZMap(*vs.Map) {
             const map = self.zapi.getFramePropertiesRW(self.frame).?;


### PR DESCRIPTION
This project builds just fine with older zig versions, there's no need to force the use of Zig 0.16.0. The minimum is a minimum, not a maximum.